### PR TITLE
Disable service manipulation via package hooks

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -38,7 +38,12 @@ override_dh_installdocs:
 	dh_installdocs -O--buildsystem=python_distutils
 
 override_dh_installinit:
-	dh_installinit -O--buildsystem=python_distutils --name rtslib-fb-targetctl
+	dh_installinit \
+		--no-start \
+		--no-enable \
+		--no-stop-on-upgrade \
+		--no-restart-after-upgrade \
+		-O--buildsystem=python_distutils --name rtslib-fb-targetctl
 
 override_dh_auto_clean:
 	dh_auto_clean -O--buildsystem=python_distutils


### PR DESCRIPTION
By default, the "dh_installinit" packer helper will add logic to the
postinst, postrm, and prerm packaging hooks to manipulate the service
during package installtion, upgrade, and removal. As a result, the
service is automatically stopped during an upgrade, which is not what we
want to occur on a Delphix appliance. This change adds the required
options to "dh_installinit" to prevent this.