### PR TITLE
DLPX-77937 python-rtslib-fb: should ensure we keep dbroot on /var/target

### DIFF
--- a/rtslib/fabric.py
+++ b/rtslib/fabric.py
@@ -486,3 +486,7 @@ class FabricModule(object):
     def all(cls):
         for mod in six.itervalues(fabric_modules):
             yield mod()
+
+    @classmethod
+    def list_registered_drivers(cls):
+        return os.listdir('/sys/module/target_core_mod/holders')

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -167,6 +167,14 @@ class RTSRoot(CFSNode):
             return
         self._dbroot = fread(dbroot_path)
         if self._dbroot != self._preferred_dbroot:
+            if len(FabricModule.list_registered_drivers()) is not 0:
+                # Writing to dbroot_path after drivers have been registered will make the kernel emit this error:
+                # db_root: cannot be changed: target drivers registered
+                from warnings import warn
+                warn("Cannot set dbroot to {}. Target drivers have already been registered."
+                     .format(self._preferred_dbroot))
+                return
+
             try:
                 fwrite(dbroot_path, self._preferred_dbroot+"\n")
             except:

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -85,7 +85,7 @@ class RTSRoot(CFSNode):
             modprobe('target_core_mod')
             self._create_in_cfs_ine('any')
 
-        self._set_dbroot_if_needed()
+        self._set_dbroot()
 
     def _list_targets(self):
         self._check_self()
@@ -160,7 +160,7 @@ class RTSRoot(CFSNode):
     def __str__(self):
         return "rtslib"
 
-    def _set_dbroot_if_needed(self):
+    def _set_dbroot(self):
         dbroot_path = self.path + "/dbroot"
         if not os.path.exists(dbroot_path):
             self._dbroot = self._default_dbroot

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -167,7 +167,7 @@ class RTSRoot(CFSNode):
             return
         self._dbroot = fread(dbroot_path)
         if self._dbroot != self._preferred_dbroot:
-            if len(FabricModule.list_registered_drivers()) is not 0:
+            if len(FabricModule.list_registered_drivers()) != 0:
                 # Writing to dbroot_path after drivers have been registered will make the kernel emit this error:
                 # db_root: cannot be changed: target drivers registered
                 from warnings import warn

--- a/rtslib/root.py
+++ b/rtslib/root.py
@@ -166,6 +166,21 @@ class RTSRoot(CFSNode):
             self._dbroot = self._default_dbroot
             return
         self._dbroot = fread(dbroot_path)
+
+        #
+        # Delphix: previous persistent reservation data would have been stored
+        # under /var/target (_default_dbroot). If we want to change the location
+        # of the pr data we would first need to migrate the existing data,
+        # which we have not currently implemented.
+        #
+        # By default the kernel will try to use /etc/target if it exists,
+        # and if not it will go to /var/target (which is our case). We add a
+        # check here to ensure that the kernel indeed points to /var/target.
+        # If that is not the case we would catch this failure in our testing.
+        #
+        assert self._dbroot == self._default_dbroot
+        return
+
         if self._dbroot != self._preferred_dbroot:
             if len(FabricModule.list_registered_drivers()) != 0:
                 # Writing to dbroot_path after drivers have been registered will make the kernel emit this error:


### PR DESCRIPTION
This PR pulls a few changes from upstream, whereas the last change is an addition from me.
The changes pulled from upstream are necessary to avoid a bug seen during upgrade to focal:
```
Aug 12 07:03:39 ip-10-110-233-234 systemd[1]: Stopping Restore LIO kernel target configuration...
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: OSError: [Errno 22] Invalid argument
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: During handling of the above exception, another exception occurred:
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: Traceback (most recent call last):
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/lib/python3/dist-packages/rtslib_fb/root.py", line 171, in _set_dbroot_if_needed
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     fwrite(dbroot_path, self._preferred_dbroot+"\n")
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/lib/python3/dist-packages/rtslib_fb/utils.py", line 79, in fwrite
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     file_fd.write(str(string))
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: OSError: [Errno 22] Invalid argument
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: During handling of the above exception, another exception occurred:
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: Traceback (most recent call last):
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/bin/targetctl", line 127, in <module>
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     main()
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/bin/targetctl", line 124, in main
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     funcs[sys.argv[1]](savefile)
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/bin/targetctl", line 68, in clear
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     RTSRoot().clear_existing(confirm=True)
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/lib/python3/dist-packages/rtslib_fb/root.py", line 88, in __init__
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     self._set_dbroot_if_needed()
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:   File "/usr/lib/python3/dist-packages/rtslib_fb/root.py", line 174, in _set_dbroot_if_needed
Aug 12 07:03:39 ip-10-110-233-234 target[22998]:     raise RTSLibError("Cannot set dbroot to {}. Please check if this directory exists."
Aug 12 07:03:39 ip-10-110-233-234 target[22998]: rtslib_fb.utils.RTSLibError: Cannot set dbroot to /etc/rtslib-fb-target. Please check if this directory exists.
Aug 12 07:03:39 ip-10-110-233-234 systemd[1]: rtslib-fb-targetctl.service: Control process exited, code=exited, status=1/FAILURE
Aug 12 07:03:39 ip-10-110-233-234 systemd[1]: rtslib-fb-targetctl.service: Failed with result 'exit-code'.
Aug 12 07:03:39 ip-10-110-233-234 systemd[1]: Stopped Restore LIO kernel target configuration.
```

The change I've added is there to ensure that we keep using the same "dbroot". The target driver in the kernel happens to read/write data into a specific location on the filesystem, under "dbroot", and that location can be changed. The default location used to be `/var/target`, but now it prefers using `/etc/target` when that directory exists. On the Delphix Appliance, /etc/traget doesn't exist so it keeps using the old location by default. The check I've added ensures that if `/etc/target` were to exist we'd fail starting the rtslib-fb-targetctl service and fix the situation.

Currently the only data being written to dbroot is the SCSI3 persistent reservation info, but we do use that feature in some configurations, so if we wanted to adopt the new preferred `/etc/target` location we'd have to migrate the existing PR data to the new location and then do a call into the kernel to change the dbroot to the new location. The problem is that the call to change the dbroot works only when there are no fabric modules registered, which is only the case at boot before we enable the rtslib-fb-targetctl service. We could add some logic to migrate the dbroot on next boot, but I decided against that for now since that introduces extra complexity.

Note that this PR is targeting the `projects/focal` branch. The reason for this is that this code is already on the `focal` branch, but didn't go through the regular review process; this PR will allow us to have a review process for this code. Once it lands on `projects/focal`, I'll force-push those changes to `focal`.

## Testing
This code has been soaking on the focal branch for over a month now.